### PR TITLE
Optimize switching animations to avoid flickering

### DIFF
--- a/src/GridLayout.cpp
+++ b/src/GridLayout.cpp
@@ -292,28 +292,28 @@ void GridLayout::moveWindowTo(CWindow *, const std::string &dir)
     ; // empty
 }
 
-// void GridLayout::changeToActivceSourceWorkspace()
-// {
-//     CWindow *pWindow = nullptr;
-//     SGridNodeData *pNode;
-//     CWorkspace *pWorksapce;
-//     hycov_log(LOG,"changeToActivceSourceWorkspace");
-//     pWindow = g_pCompositor->m_pLastWindow;
-//     const auto pMonitor = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID); 
-//     pNode = getNodeFromWindow(pWindow);
-//     if(pNode) {
-//         pWorksapce = g_pCompositor->getWorkspaceByID(pNode->ovbk_windowWorkspaceId); 
-//         // pMonitor->activeWorkspace = pNode->ovbk_windowWorkspaceId;
-//     } else {
-//         pWorksapce = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID); 
-//         // pMonitor->activeWorkspace = pWindow->m_iWorkspaceID;        
-//     }
-//     pMonitor->changeWorkspace(pWorksapce);
-//     hycov_log(LOG,"changeToWorkspace:{}",pWorksapce->m_iID);
-//     g_pEventManager->postEvent(SHyprIPCEvent{"workspace", pWorksapce->m_szName});
-//     EMIT_HOOK_EVENT("workspace", pWorksapce);
-//     // g_pCompositor->focusWindow(pWindow);
-// }
+void GridLayout::changeToActivceSourceWorkspace()
+{
+    CWindow *pWindow = nullptr;
+    SGridNodeData *pNode;
+    CWorkspace *pWorksapce;
+    hycov_log(LOG,"changeToActivceSourceWorkspace");
+    pWindow = g_pCompositor->m_pLastWindow;
+    const auto pMonitor = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID); 
+    pNode = getNodeFromWindow(pWindow);
+    if(pNode) {
+        pWorksapce = g_pCompositor->getWorkspaceByID(pNode->ovbk_windowWorkspaceId); 
+        // pMonitor->activeWorkspace = pNode->ovbk_windowWorkspaceId;
+    } else {
+        pWorksapce = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID); 
+        // pMonitor->activeWorkspace = pWindow->m_iWorkspaceID;        
+    }
+    pMonitor->changeWorkspace(pWorksapce);
+    hycov_log(LOG,"changeToWorkspace:{}",pWorksapce->m_iID);
+    // g_pEventManager->postEvent(SHyprIPCEvent{"workspace", pWorksapce->m_szName});
+    // EMIT_HOOK_EVENT("workspace", pWorksapce);
+    // g_pCompositor->focusWindow(pWindow);
+}
 
 void GridLayout::moveWindowToSourceWorkspace()
 {

--- a/src/GridLayout.cpp
+++ b/src/GridLayout.cpp
@@ -292,28 +292,28 @@ void GridLayout::moveWindowTo(CWindow *, const std::string &dir)
     ; // empty
 }
 
-void GridLayout::changeToActivceSourceWorkspace()
-{
-    CWindow *pWindow = nullptr;
-    SGridNodeData *pNode;
-    CWorkspace *pWorksapce;
-    hycov_log(LOG,"changeToActivceSourceWorkspace");
-    pWindow = g_pCompositor->m_pLastWindow;
-    const auto pMonitor = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID); 
-    pNode = getNodeFromWindow(pWindow);
-    if(pNode) {
-        pWorksapce = g_pCompositor->getWorkspaceByID(pNode->ovbk_windowWorkspaceId); 
-        // pMonitor->activeWorkspace = pNode->ovbk_windowWorkspaceId;
-    } else {
-        pWorksapce = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID); 
-        // pMonitor->activeWorkspace = pWindow->m_iWorkspaceID;        
-    }
-    pMonitor->changeWorkspace(pWorksapce);
-
-    hycov_log(LOG,"changeToWorkspace:{}",pWorksapce->m_iID);
-    g_pEventManager->postEvent(SHyprIPCEvent{"workspace", pWorksapce->m_szName});
-    EMIT_HOOK_EVENT("workspace", pWorksapce);
-}
+// void GridLayout::changeToActivceSourceWorkspace()
+// {
+//     CWindow *pWindow = nullptr;
+//     SGridNodeData *pNode;
+//     CWorkspace *pWorksapce;
+//     hycov_log(LOG,"changeToActivceSourceWorkspace");
+//     pWindow = g_pCompositor->m_pLastWindow;
+//     const auto pMonitor = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID); 
+//     pNode = getNodeFromWindow(pWindow);
+//     if(pNode) {
+//         pWorksapce = g_pCompositor->getWorkspaceByID(pNode->ovbk_windowWorkspaceId); 
+//         // pMonitor->activeWorkspace = pNode->ovbk_windowWorkspaceId;
+//     } else {
+//         pWorksapce = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID); 
+//         // pMonitor->activeWorkspace = pWindow->m_iWorkspaceID;        
+//     }
+//     pMonitor->changeWorkspace(pWorksapce);
+//     hycov_log(LOG,"changeToWorkspace:{}",pWorksapce->m_iID);
+//     g_pEventManager->postEvent(SHyprIPCEvent{"workspace", pWorksapce->m_szName});
+//     EMIT_HOOK_EVENT("workspace", pWorksapce);
+//     // g_pCompositor->focusWindow(pWindow);
+// }
 
 void GridLayout::moveWindowToSourceWorkspace()
 {

--- a/src/GridLayout.hpp
+++ b/src/GridLayout.hpp
@@ -48,11 +48,10 @@ public:
   void calculateWorkspace(const int &);
   int getNodesNumOnWorkspace(const int &);
   SGridNodeData *getNodeFromWindow(CWindow *);
-  void changeToActivceSourceWorkspace();
   void resizeNodeSizePos(SGridNodeData *, int, int, int, int);
   void moveWindowToWorkspaceSilent(CWindow *, const int &);
   std::list<SGridNodeData> m_lGridNodesData; 
   void moveWindowToSourceWorkspace();
-
+  // void changeToActivceSourceWorkspace();
 private:
 };

--- a/src/GridLayout.hpp
+++ b/src/GridLayout.hpp
@@ -52,6 +52,6 @@ public:
   void moveWindowToWorkspaceSilent(CWindow *, const int &);
   std::list<SGridNodeData> m_lGridNodesData; 
   void moveWindowToSourceWorkspace();
-  // void changeToActivceSourceWorkspace();
+  void changeToActivceSourceWorkspace();
 private:
 };

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -292,7 +292,9 @@ void dispatch_leaveoverview(std::string arg)
 	
 	hycov_log(LOG,"leave overview");
 	g_isOverView = false;
-
+	//mark exiting overview mode
+	g_isOverViewExiting = true;
+	
 	//restore workspace name
 	g_pCompositor->renameWorkspace(workspaceIdBackup,workspaceNameBackup);
 
@@ -317,9 +319,8 @@ void dispatch_leaveoverview(std::string arg)
 
 	//move clients to it's original workspace 
 	g_GridLayout->moveWindowToSourceWorkspace();
-	//jump to target client's workspace
-	g_GridLayout->changeToActivceSourceWorkspace();
-
+	// g_GridLayout->changeToActivceSourceWorkspace();
+	
 	for (auto &n : g_GridLayout->m_lGridNodesData)
 	{	
 		if (n.ovbk_windowIsFloating)
@@ -390,7 +391,9 @@ void dispatch_leaveoverview(std::string arg)
 
 	//clean overview layout node date
 	g_GridLayout->m_lGridNodesData.clear();
-	
+
+	//mark has exited mode
+	g_isOverViewExiting = false;
 	return;
 }
 

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -314,12 +314,13 @@ void dispatch_leaveoverview(std::string arg)
 	{
 		g_pLayoutManager->switchToLayout(*configLayoutName);	
 		g_GridLayout->m_lGridNodesData.clear();
+		g_isOverViewExiting = false;
 		return;
 	}
 
 	//move clients to it's original workspace 
 	g_GridLayout->moveWindowToSourceWorkspace();
-	// g_GridLayout->changeToActivceSourceWorkspace();
+	g_GridLayout->changeToActivceSourceWorkspace();
 	
 	for (auto &n : g_GridLayout->m_lGridNodesData)
 	{	
@@ -392,7 +393,7 @@ void dispatch_leaveoverview(std::string arg)
 	//clean overview layout node date
 	g_GridLayout->m_lGridNodesData.clear();
 
-	//mark has exited mode
+	//mark has exited overview mode
 	g_isOverViewExiting = false;
 	return;
 }

--- a/src/globaleventhook.cpp
+++ b/src/globaleventhook.cpp
@@ -150,10 +150,12 @@ static void hkSpawn(void* thisptr, std::string args) {
 }
 
 static void hkStartAnim(void* thisptr,bool in, bool left, bool instant = false) {
-  if (!g_isOverViewExiting) {
-    (*(origStartAnim)g_pStartAnimHook->m_pOriginal)(thisptr, in, left, instant);
-  } else {
+  if (g_isOverViewExiting) {
     (*(origStartAnim)g_pStartAnimHook->m_pOriginal)(thisptr, in, left, true);
+    hycov_log(LOG,"hook startAnim,disable workspace change anim,in:{},isOverview:{}",in,g_isOverView);
+  } else {
+    (*(origStartAnim)g_pStartAnimHook->m_pOriginal)(thisptr, in, left, instant);
+    hycov_log(LOG,"hook startAnim,enable workspace change anim,in:{},isOverview:{}",in,g_isOverView);
   }
 }
 

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -21,6 +21,7 @@ inline int g_disable_spawn;
 inline int g_auto_exit;
 inline int g_auto_fullscreen;
 inline int g_only_active_workspace;
+inline bool g_isOverViewExiting;
 
 inline CFunctionHook* g_pOnSwipeBeginHook = nullptr;
 inline CFunctionHook* g_pOnSwipeEndHook = nullptr;
@@ -29,6 +30,7 @@ inline CFunctionHook* g_pOnWindowRemovedTilingHook = nullptr;
 inline CFunctionHook* g_pChangeworkspaceHook = nullptr;
 inline CFunctionHook* g_pMoveActiveToWorkspaceHook = nullptr;
 inline CFunctionHook* g_pSpawnHook = nullptr;
+inline CFunctionHook* g_pStartAnimHook = nullptr;
 
 inline void errorNotif()
 {


### PR DESCRIPTION
Disable workspace animation when the overview is switched to normal mode to prevent Windows from flying off the screen and back, which may cause animation to flicker