### PR TITLE
Fix: Some special cases exit the ov mode so that the normal window is not visible

### DIFF
--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -491,7 +491,7 @@ void dispatch_leaveoverview(std::string arg)
 		}
 		
 		// if client not in old layout,create tiling of the client
-		if (!n.isInOldLayout) {
+		if (!n.isInOldLayout || (n.ovbk_size.x == 0 && n.ovbk_size.y == 0)) {
 			g_pLayoutManager->getCurrentLayout()->onWindowCreatedTiling(n.pWindow);
 		}
 	}


### PR DESCRIPTION
Fix: When the application floating landing window switches to the normal window, the ov mode is triggered to exit, and the normal window of the application is not visible in the normal mode after exiting the ov mode