### PR TITLE
fix:info.cancel lose efficacy in new version hyprland

### DIFF
--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -49,6 +49,7 @@ inline CFunctionHook* g_pHyprDwindleLayout_recalculateMonitor = nullptr;
 inline CFunctionHook* g_pHyprMasterLayout_recalculateMonitor = nullptr;
 inline CFunctionHook* g_pHyprDwindleLayout_recalculateWindow = nullptr;
 inline CFunctionHook* g_pSDwindleNodeData_recalcSizePosRecursive = nullptr;
+inline CFunctionHook* g_pCInputManager_onMouseButton = nullptr;
 
 inline void errorNotif()
 {


### PR DESCRIPTION
The event hook in the new version of hyrpland does not prevent events from being passed to the client, and instead hooks the original event directly