### PR TITLE
feature: add option hotarea_pos and hotarea_monitor

### DIFF
--- a/src/globaleventhook.cpp
+++ b/src/globaleventhook.cpp
@@ -109,24 +109,29 @@ static void toggle_hotarea(int x_root, int y_root)
   CMonitor *pMonitor = g_pCompositor->m_pLastMonitor;
   std::string arg = "";
 
+  if (g_hotarea_monitor != "all" && pMonitor->szName != g_hotarea_monitor)
+    return;
+
   auto m_x = pMonitor->vecPosition.x;
   auto m_y = pMonitor->vecPosition.y;
+  auto m_width = pMonitor->vecSize.x;
   auto m_height = pMonitor->vecSize.y;
 
-  int hx = m_x + g_hotarea_size;
-  int hy = m_y + m_height - g_hotarea_size;
-
-  if (!g_isInHotArea && y_root > hy &&
-      x_root < hx && x_root >= m_x &&
-      y_root <= (m_y + m_height))
+  if (!g_isInHotArea &&
+    ((g_hotarea_pos == 1 && x_root < (m_x + g_hotarea_size) && y_root < (m_y + g_hotarea_size)) ||
+    (g_hotarea_pos == 2 && x_root > (m_x + m_width - g_hotarea_size) && y_root < (m_y + g_hotarea_size)) ||
+    (g_hotarea_pos == 3 && x_root < (m_x + g_hotarea_size) && y_root > (m_y + m_height - g_hotarea_size)) ||
+    (g_hotarea_pos == 4 && x_root > (m_x + m_width - g_hotarea_size) && y_root > (m_y + m_height - g_hotarea_size))))
   {
     hycov_log(LOG,"cursor enter hotarea");
     dispatch_toggleoverview("internalToggle");
     g_isInHotArea = true;
   }
   else if (g_isInHotArea &&
-           (y_root <= hy || x_root >= hx || x_root < m_x ||
-            y_root > (m_y + m_height)))
+    !((g_hotarea_pos == 1 && x_root < (m_x + g_hotarea_size) && y_root < (m_y + g_hotarea_size)) ||
+    (g_hotarea_pos == 2 && x_root > (m_x + m_width - g_hotarea_size) && y_root < (m_y + g_hotarea_size)) ||
+    (g_hotarea_pos == 3 && x_root < (m_x + g_hotarea_size) && y_root > (m_y + m_height - g_hotarea_size)) ||
+    (g_hotarea_pos == 4 && x_root > (m_x + m_width - g_hotarea_size) && y_root > (m_y + m_height - g_hotarea_size))))
   {
     if(g_isInHotArea)
       g_isInHotArea = false;

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -19,6 +19,8 @@ inline std::unique_ptr<GridLayout> g_GridLayout;
 inline bool g_isOverView;
 inline bool g_isInHotArea;
 inline int g_enable_hotarea;
+inline std::string g_hotarea_monitor;
+inline int g_hotarea_pos;
 inline int g_hotarea_size;
 inline unsigned int g_swipe_fingers;
 inline int g_isGestureBegin;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle)
 	CONF("overview_gappo", int, 60);
 	CONF("overview_gappi", int, 24);
 	CONF("hotarea_size", int, 10);
+	CONF("hotarea_monitor", str, "all");
+  CONF("hotarea_pos", int, 1);
 	CONF("enable_hotarea", int, 1);
 	CONF("swipe_fingers", int, 4);
 	CONF("move_focus_distance", int, 100);
@@ -35,7 +37,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle)
 #undef CONF
 
 	static const auto *pEnable_hotarea_config = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hycov:enable_hotarea")->intValue;
-  	static const auto *pHotarea_size_config = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hycov:hotarea_size")->intValue;
+  static const auto *pHotarea_monitor_config = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hycov:hotarea_monitor")->strValue;
+  static const auto *pHotarea_pos_config = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hycov:hotarea_pos")->intValue;
+  static const auto *pHotarea_size_config = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hycov:hotarea_size")->intValue;
 	static const auto *pSwipe_fingers_config = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hycov:swipe_fingers")->intValue;
 	static const auto *pMove_focus_distance_config = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hycov:move_focus_distance")->intValue;
 	static const auto *pEnable_gesture_config = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hycov:enable_gesture")->intValue;
@@ -53,6 +57,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle)
 
 
 	g_enable_hotarea = *pEnable_hotarea_config;
+	g_hotarea_monitor = *pHotarea_monitor_config;
+	g_hotarea_pos = *pHotarea_pos_config;
 	g_hotarea_size = *pHotarea_size_config;
 	g_swipe_fingers = *pSwipe_fingers_config;
 	g_move_focus_distance = *pMove_focus_distance_config;


### PR DESCRIPTION
Add two new config options: hotarea_pos and hotarea_monitor.

Currently hycov only support triggering hot area at the bottom left corner of all monitors. But users may want to change this to top right etc., and users with multiple monitors may want to use hot area on only one monitor.

This pr implements these two options.

```
hotarea_pos = 1 # 1: top left, 2: top right, 3: bottom left, 4: bottom right
hotarea_monitor = HDMI-A-1 # default is all
```

TODOs:
- [ ] update  readme
- [ ] be able to set multiple hotarea_monitor