### PR TITLE
Make example flake pin hyprland version to official hyprland flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ alt_replace_key = code:133 # use `xev` command to get keycode
           {
             wayland.windowManager.hyprland = {
               enable = true;
+              package = hyprland.packages."${pkgs.system}".hyprland;
               plugins = [
                 hycov.packages.${pkgs.system}.hycov
               ];


### PR DESCRIPTION
The current example Flake works, but is prone to breakage if the nixos-latest Hyprland package ever falls behind, and also is not resilient to the user wanting to use a different package repository from nix (view: #79 .) This change makes the example more robust.