### PR TITLE
Fixes for newest Hyprland

### DIFF
--- a/src/OvGridLayout.cpp
+++ b/src/OvGridLayout.cpp
@@ -77,7 +77,7 @@ void OvGridLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection direction
 {
     CMonitor *pTargetMonitor;
     if(g_hycov_forece_display_all_in_one_monitor) {
-        pTargetMonitor = g_pCompositor->m_pLastMonitor;
+        pTargetMonitor = g_pCompositor->m_pLastMonitor.get();
     } else {
       pTargetMonitor =  g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID); 
     }

--- a/src/OvGridLayout.cpp
+++ b/src/OvGridLayout.cpp
@@ -396,6 +396,10 @@ void OvGridLayout::calculateWorkspace(const int &ws)
 void OvGridLayout::recalculateMonitor(const int &monid)
 {
     const auto pMonitor = g_pCompositor->getMonitorFromID(monid);                       // 根据monitor id获取monitor对象
+
+    if (!pMonitor || !pMonitor->activeWorkspace)
+        return;
+
     g_pHyprRenderer->damageMonitor(pMonitor); // Use local rendering
 
     if (pMonitor->activeSpecialWorkspaceID()) {

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -383,7 +383,7 @@ void dispatch_enteroverview(std::string arg)
 	g_pLayoutManager->getCurrentLayout()->onEnable();
 
 	//change workspace name to OVERVIEW
-	pActiveMonitor	= g_pCompositor->m_pLastMonitor;
+	pActiveMonitor	= g_pCompositor->m_pLastMonitor.get();
 	pActiveWorkspace = g_pCompositor->getWorkspaceByID(pActiveMonitor->activeWorkspace->m_iID);
 	workspaceNameBackup = pActiveWorkspace->m_szName;
 	workspaceIdBackup = pActiveWorkspace->m_iID;

--- a/src/globaleventhook.cpp
+++ b/src/globaleventhook.cpp
@@ -106,7 +106,7 @@ static void hkOnSwipeEnd(void* thisptr, wlr_pointer_swipe_end_event* e) {
 
 static void toggle_hotarea(int x_root, int y_root)
 {
-  CMonitor *pMonitor = g_pCompositor->m_pLastMonitor;
+  CMonitor *pMonitor = g_pCompositor->m_pLastMonitor.get();
 
   if (g_hycov_hotarea_monitor != "all" && pMonitor->szName != g_hycov_hotarea_monitor)
     return;

--- a/src/globaleventhook.cpp
+++ b/src/globaleventhook.cpp
@@ -1,5 +1,3 @@
-
-#include "globaleventhook.hpp"
 #include "dispatchers.hpp"
 #include <regex>
 #include <set>
@@ -15,7 +13,7 @@ typedef void (*origCWindow_onUnmap)(void*);
 typedef void (*origStartAnim)(void*, bool in, bool left, bool instant);
 typedef void (*origFullscreenActive)(std::string args);
 typedef void (*origOnKeyboardKey)(void*, std::any e, SP<IKeyboard> pKeyboard);
-typedef void (*origCInputManager_onMouseButton)(void* , wlr_pointer_button_event* e);
+typedef void (*origCInputManager_onMouseButton)(void*, IPointer::SButtonEvent e);
 typedef void (*origCInputManager_mouseMoveUnified)(void* , uint32_t time, bool refocus);
 
 static double gesture_dx,gesture_previous_dx;
@@ -146,9 +144,9 @@ static void hkCInputManager_mouseMoveUnified(void* thisptr, uint32_t time, bool 
   toggle_hotarea(MOUSECOORDSFLOORED.x, MOUSECOORDSFLOORED.y);
 }
 
-static void hkCInputManager_onMouseButton(void* thisptr, wlr_pointer_button_event* e)
+static void hkCInputManager_onMouseButton(void* thisptr, IPointer::SButtonEvent e)
 {
-  if(g_hycov_isOverView && (e->button == BTN_LEFT || e->button == BTN_RIGHT) ) {
+  if(g_hycov_isOverView && (e.button == BTN_LEFT || e.button == BTN_RIGHT) ) {
 
     if (g_hycov_click_in_cursor) {
         g_pInputManager->refocus();
@@ -158,17 +156,17 @@ static void hkCInputManager_onMouseButton(void* thisptr, wlr_pointer_button_even
       return;
     }
 
-    switch (e->button)
+    switch (e.button)
     {
     case BTN_LEFT:
-      if (g_hycov_isOverView && e->state == WLR_BUTTON_PRESSED)
+      if (g_hycov_isOverView && e.state == WLR_BUTTON_PRESSED)
       {
         dispatch_toggleoverview("internalToggle");
         return;
       }
       break;
     case BTN_RIGHT:
-      if (g_hycov_isOverView && e->state == WLR_BUTTON_PRESSED)
+      if (g_hycov_isOverView && e.state == WLR_BUTTON_PRESSED)
       {
         g_pCompositor->closeWindow(g_pCompositor->m_pLastWindow.lock());
         return;


### PR DESCRIPTION
This pretty much should fix most of the crashes and compiling incompatibilities.

The one problem, I haven't had time to figure it out, was with `CWindow::onUnmap`. For some reason, if you turn on `g_hycov_auto_exit` and exit XWayland window the whole Hyprland crashes. 

Basically, it just tries to set “end” callback to `unregisterVariable` function, but that somewhere along the way fails while trying to execute it.

Edit: Probably worth mentioning that my setup is on NVIDIA card. Also if you were to enable legacy rendering, it does not crash anymore, however strange artefacts appear if you enable hycov (not sure whether this is Hyprland's issue or this plugin)

Whole stack is:
```
#0  x86_64_fallback_frame_state (context=0x7ffd14491170, fs=0x7ffd14491260) at ./md-unwind-support.h:63
#1  uw_frame_state_for (context=context@entry=0x7ffd14491170, fs=fs@entry=0x7ffd14491260) at /usr/src/debug/gcc/gcc/libgcc/unwind-dw2.c:1013
#2  0x000079e2a5ae2cee in _Unwind_Backtrace (trace=0x79e2a5735370, trace_argument=0x7ffd144913a0) at /usr/src/debug/gcc/gcc/libgcc/unwind.inc:303
#3  0x000079e2a5735471 in backtrace () at /usr/lib/libc.so.6
#4  0x00005a84b99be5e6 in getBacktrace () at ../src/helpers/MiscFunctions.cpp:840
#5  0x00005a84b9924c75 in CrashReporter::createAndSaveCrash (sig=sig@entry=11) at ../src/debug/CrashReporter.cpp:165
#6  0x00005a84b98b3a5c in handleUnrecoverableSignal (sig=11) at ../src/Compositor.cpp:55
#7  0x000079e2a5650ae0 in <signal handler called> () at /usr/lib/libc.so.6
#8  0x00000000b99774f0 in ??? ()
#9  0x00005a84b997771f in std::function<void (void*)>::operator()(void*) const (this=0x5a84c53a5d18, __args#0=<optimized out>)
    at /usr/include/c++/14.1.1/bits/std_function.h:587
#10 CBaseAnimatedVariable::onAnimationEnd (this=0x5a84c53a5cd0) at ../src/config/../helpers/../desktop/../helpers/AnimatedVariable.hpp:183
#11 0x00005a84b996b404 in CBaseAnimatedVariable::setCallbackOnEnd(std::function<void (void*)>, bool) (this=0x5a84c53a5cd0, func=..., remove=true)
    at ../src/config/../helpers/../desktop/../helpers/AnimatedVariable.hpp:118
#12 CWindow::onUnmap (this=0x5a84c53a5220) at ../src/desktop/Window.cpp:485
#13 0x000079e2a0903fa6 in hkCWindow_onUnmap (thisptr=<optimized out>) at /tmp/hyprpm/REDACTED/src/globaleventhook.cpp:184
#14 0x00005a84b99ab678 in Events::listener_unmapWindow (owner=<optimized out>, data=<optimized out>) at ../src/events/Windows.cpp:778
#15 0x00005a84b99d84c9 in std::function<void (void*, void*)>::operator()(void*, void*) const (this=<optimized out>, __args#0=<optimized out>, __args#1=0x0)
    at /usr/include/c++/14.1.1/bits/std_function.h:591
#16 CHyprWLListener::emit (this=<optimized out>, data=0x0) at ../src/helpers/WLListener.cpp:61
#17 handleWrapped (listener=0x5a84c53a52f0, data=0x0) at ../src/helpers/WLListener.cpp:14
#18 0x000079e2a614601e in wl_signal_emit_mutable () at /usr/lib/libwayland-server.so.0
#19 0x00005a84b9be9d39 in wlr_surface_unmap (surface=0x5a84c51cb7e0) at ../subprojects/wlroots-hyprland/types/wlr_compositor.c:830
#20 wlr_surface_unmap (surface=0x5a84c51cb7e0) at ../subprojects/wlroots-hyprland/types/wlr_compositor.c:825
#21 0x00005a84b9bfbd25 in xwayland_surface_dissociate (xsurface=0x5a84c53a4ee0) at ../subprojects/wlroots-hyprland/xwayland/xwm.c:440
#22 xwm_handle_unmap_notify (ev=0x5a84c51b12f0, xwm=0x5a84c5443f90) at ../subprojects/wlroots-hyprland/xwayland/xwm.c:1153
#23 x11_event_handler (fd=<optimized out>, mask=<optimized out>, data=<optimized out>) at ../subprojects/wlroots-hyprland/xwayland/xwm.c:1707
#24 x11_event_handler (fd=<optimized out>, mask=<optimized out>, data=0x5a84c5443f90) at ../subprojects/wlroots-hyprland/xwayland/xwm.c:1661
#25 0x000079e2a6147ae2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#26 0x000079e2a61482d7 in wl_display_run () at /usr/lib/libwayland-server.so.0
#27 0x00005a84b9a636fb in CEventLoopManager::enterLoop (this=<optimized out>, display=<optimized out>, wlEventLoop=<optimized out>)
    at ../src/managers/eventLoop/EventLoopManager.cpp:27
#28 0x00005a84b98c98ea in CCompositor::startCompositor (this=<optimized out>) at ../src/Compositor.cpp:575
#29 0x00005a84b9835db5 in main (argc=<optimized out>, argv=<optimized out>) at /usr/include/c++/14.1.1/bits/unique_ptr.h:193```