### PR TITLE
Flake: Add overlays

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,35 +1,69 @@
 {
   "nodes": {
-    "hyprland": {
+    "hyprcursor": {
       "inputs": {
-        "hyprland-protocols": "hyprland-protocols",
-        "nixpkgs": "nixpkgs",
-        "systems": "systems",
-        "wlroots": "wlroots",
-        "xdph": "xdph"
-      },
-      "locked": {
-        "lastModified": 1698018813,
-        "narHash": "sha256-JMg+HRyTOZK3W8pRNyJTp7AOWYkbs+LaKqAFc+cScyM=",
-        "owner": "hyprwm",
-        "repo": "Hyprland",
-        "rev": "015664eb4cde5ab93cfacbfd8c2e831eeb876634",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "Hyprland",
-        "type": "github"
-      }
-    },
-    "hyprland-protocols": {
-      "inputs": {
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
         ],
         "systems": [
           "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717181720,
+        "narHash": "sha256-yv+QZWsusu/NWjydkxixHC2g+tIJ9v+xkE2EiVpJj6g=",
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "rev": "9e27a2c2ceb1e0b85bd55b0afefad196056fe87c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "type": "github"
+      }
+    },
+    "hyprland": {
+      "inputs": {
+        "hyprcursor": "hyprcursor",
+        "hyprlang": "hyprlang",
+        "hyprwayland-scanner": "hyprwayland-scanner",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "xdph": "xdph"
+      },
+      "locked": {
+        "lastModified": 1717970802,
+        "narHash": "sha256-kFnaAmte/N1mrbHEQyrwDu9+laZzVAi4N2nQodCNfgg=",
+        "ref": "refs/heads/main",
+        "rev": "1423707dbefc0329e80895451903a77ab684f7ea",
+        "revCount": 4789,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/hyprwm/Hyprland"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/hyprwm/Hyprland"
+      }
+    },
+    "hyprland-protocols": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "xdph",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "xdph",
           "systems"
         ]
       },
@@ -47,13 +81,63 @@
         "type": "github"
       }
     },
+    "hyprlang": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716473782,
+        "narHash": "sha256-+qLn4lsHU6iL3+HTo1gTQ1tWzet8K9h+IfVemzEQZj8=",
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "rev": "87d5d984109c839482b88b4795db073eb9ed446f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "type": "github"
+      }
+    },
+    "hyprwayland-scanner": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717784906,
+        "narHash": "sha256-YxmfxHfWed1fosaa7fC1u7XoKp1anEZU+7Lh/ojRKoM=",
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "rev": "0f30f9eca6e404130988554accbb64d1c9ec877d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694767346,
-        "narHash": "sha256-5uH27SiVFUwsTsqC5rs3kS7pBoNhtoy9QfTP9BmknGk=",
+        "lastModified": 1717602782,
+        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ace5093e36ab1e95cb9463863491bee90d5a4183",
+        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
         "type": "github"
       },
       "original": {
@@ -83,30 +167,12 @@
         "type": "github"
       }
     },
-    "wlroots": {
-      "flake": false,
-      "locked": {
-        "host": "gitlab.freedesktop.org",
-        "lastModified": 1696410538,
-        "narHash": "sha256-ecDhdYLXWHsxMv+EWG36mCNDvzRbu9qfjH7dLxL7aGM=",
-        "owner": "wlroots",
-        "repo": "wlroots",
-        "rev": "3406c1b17a4a7e6d4e2a7d9c1176affa72bce1bc",
-        "type": "gitlab"
-      },
-      "original": {
-        "host": "gitlab.freedesktop.org",
-        "owner": "wlroots",
-        "repo": "wlroots",
-        "rev": "3406c1b17a4a7e6d4e2a7d9c1176affa72bce1bc",
-        "type": "gitlab"
-      }
-    },
     "xdph": {
       "inputs": {
-        "hyprland-protocols": [
+        "hyprland-protocols": "hyprland-protocols",
+        "hyprlang": [
           "hyprland",
-          "hyprland-protocols"
+          "hyprlang"
         ],
         "nixpkgs": [
           "hyprland",
@@ -118,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694628480,
-        "narHash": "sha256-Qg9hstRw0pvjGu5hStkr2UX1D73RYcQ9Ns/KnZMIm9w=",
+        "lastModified": 1716290197,
+        "narHash": "sha256-1u9Exrc7yx9qtES2brDh7/DDZ8w8ap1nboIOAtCgeuM=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "8f45a6435069b9e24ebd3160eda736d7a391cbf2",
+        "rev": "91e48d6acd8a5a611d26f925e51559ab743bc438",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -149,7 +149,15 @@
     },
     "root": {
       "inputs": {
-        "hyprland": "hyprland"
+        "hyprland": "hyprland",
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,21 @@
 {
   description = "Hyprland Plugins (Hycov)";
 
-  inputs.hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
+  inputs = {
+    hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
+    nixpkgs.follows = "hyprland/nixpkgs";
+    systems.follows = "hyprland/systems";
+  };
 
   outputs =
     { self
     , hyprland
+    , nixpkgs
+    , systems
     }:
     let
-      inherit (hyprland.inputs) nixpkgs;
       inherit (nixpkgs) lib;
-      systems = lib.attrNames hyprland.packages;
-      withPkgsFor = fn: lib.genAttrs systems (system:
+      withPkgsFor = fn: lib.genAttrs (import systems) (system:
         let
           pkgs = import nixpkgs {
             localSystem.system = system;

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Hyprland Plugins";
 
-  inputs.hyprland.url = "github:hyprwm/Hyprland";
+  inputs.hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
 
   outputs =
     { self

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,50 @@
 {
-  description = "Hyprland Plugins";
+  description = "Hyprland Plugins (Hycov)";
 
   inputs.hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
 
   outputs =
     { self
     , hyprland
-    ,
     }:
     let
       inherit (hyprland.inputs) nixpkgs;
-      withPkgsFor = fn: nixpkgs.lib.genAttrs (builtins.attrNames hyprland.packages) (system: fn system nixpkgs.legacyPackages.${system});
+      inherit (nixpkgs) lib;
+      systems = lib.attrNames hyprland.packages;
+      withPkgsFor = fn: lib.genAttrs systems (system:
+        let
+          pkgs = import nixpkgs {
+            localSystem.system = system;
+            overlays = [
+              hyprland.overlays.hyprland-packages
+              self.overlays.default
+            ];
+          };
+        in
+          fn system pkgs);
     in
     {
-      packages = withPkgsFor (system: pkgs: {
-        hycov = pkgs.callPackage ./default.nix {
-          inherit (hyprland.packages.${system}) hyprland;
-          stdenv = pkgs.gcc13Stdenv;
+      overlays = {
+        default = self.overlays.hycov;
+        hycov = final: prev: {
+          hyprlandPlugins = prev.hyprlandPlugins or {} // {
+            hycov = final.callPackage ./default.nix {
+              stdenv = final.gcc13Stdenv;
+            };
+          };
         };
+      };
+
+      packages = withPkgsFor (system: pkgs: {
+        default = self.packages.${system}.hycov;
+        inherit (pkgs.hyprlandPlugins) hycov;
       });
 
       devShells = withPkgsFor (system: pkgs: {
         default = pkgs.mkShell.override { stdenv = pkgs.gcc13Stdenv; } {
           name = "hyprland-plugins";
-          buildInputs = [ hyprland.packages.${system}.hyprland ];
-          inputsFrom = [ hyprland.packages.${system}.hyprland ];
+          # buildInputs = [ pkgs.hyprland ];
+          inputsFrom = [ pkgs.hycov ];
         };
       });
     };


### PR DESCRIPTION
Please make sure that the devshell still works. I think that `buildInputs` is unnecessary with `inputsFrom`, but be sure. If I'm wrong or correct, I revert or clean up respectively.

I will go through the other plugins' flakes and make similar changes. I aim to introduce the `hyprland-plugins` namespace to `pkgs` by convention.